### PR TITLE
Ignore node parsing exceptions

### DIFF
--- a/canonicalwebteam/docstring_extractor/__init__.py
+++ b/canonicalwebteam/docstring_extractor/__init__.py
@@ -28,7 +28,10 @@ def process_node(node):
     lineno = getattr(node, "lineno", 0)
 
     if docstring_text:
-        docstring = parse(docstring_text)
+        try:
+            docstring = parse(docstring_text)
+        except Exception:
+            docstring = None
     else:
         docstring = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.docstring-extractor"
-version = "0.7.0"
+version = "1.0.0"
 description = "Get Python docstrings from files"
 authors = ["Canonical Web Team <webteam@canonical.com>"]
 license = "GPL-3.0-or-later"
@@ -20,7 +20,7 @@ include = 'canonicalwebteam'
 
 [tool.poetry.dependencies]
 python = "^3.6"
-docstring-parser = "^0.9.0"
+docstring-parser = "^0.10.0"
 
 [build-system]
 requires = ['poetry>=0.12']


### PR DESCRIPTION
## Done

- Ignore invalid docstrings for nodes that could make the parser fail

## QA

QA with https://github.com/canonical-web-and-design/charmhub.io/pull/1113