### PR TITLE
Tag nodes as private

### DIFF
--- a/canonicalwebteam/docstring_extractor/__init__.py
+++ b/canonicalwebteam/docstring_extractor/__init__.py
@@ -26,6 +26,11 @@ def process_node(node, source):
     node_type = NODE_TYPES.get(type(node))
     docstring_text = ast.get_docstring(node)
     lineno = getattr(node, "lineno", 0)
+    node_name = getattr(node, "name", None)
+
+    is_private = node_name and (
+        node_name[0] == "_" and not node_name[-1] == "_"
+    )
 
     if docstring_text:
         try:
@@ -116,7 +121,7 @@ def process_node(node, source):
 
     return {
         "type": node_type,
-        "name": getattr(node, "name", None),
+        "name": node_name,
         "line": lineno,
         "docstring": docstring,
         "docstring_text": docstring_text if docstring_text else "",
@@ -125,6 +130,7 @@ def process_node(node, source):
         "description": description,
         "arguments": arguments,
         "source_segment": source,
+        "is_private": is_private,
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canonicalwebteam.docstring-extractor"
-version = "1.1.2"
+version = "1.2.0"
 description = "Get Python docstrings from files"
 authors = ["Canonical Web Team <webteam@canonical.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
If a node name begins with _, but doesn't end with a _, mark the node as private.

# QA
- QA with https://github.com/canonical/charmhub.io/pull/1488
- `dotrun` that badboy
- Visit http://localhost:8045/prometheus-k8s/libraries/prometheus_remote_write
- Compare to https://charmhub.io/prometheus-k8s/libraries/prometheus_remote_write 
- Note the lack of `_private` methods